### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: "Release"
+
+on:
+  tag:
+    name: "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  pre-release:
+    name: "Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Make Repository name lowercase
+        id: name
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ${{ env.IMAGE_NAME }}
+
+      - uses: actions/checkout@v2
+
+      - name: Setup cross compilation
+        run: cargo install cross
+          
+      - name: Build cross platform
+        run: |
+          mkdir /tmp/release-files
+          ~/.cargo/bin/cross build --release --target aarch64-unknown-linux-gnu
+          mv target/aarch64-unknown-linux-gnu/release/xd_bot ./aarch64-linux-discord_bots
+          ~/.cargo/bin/cross build --release --target x86_64-pc-windows-gnu
+          mv target/x86_64-pc-windows-gnu/release/xd_bot.exe ./win64-discord_bots.exe
+          ~/.cargo/bin/cross build --release --target x86_64-unknown-linux-gnu
+          mv target/x86_64-unknown-linux-gnu/release/xd_bot ./amd64-linux-discord_bots
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: ""
+          prerelease: false
+          draft: true
+          title: "${{ ref.event }}"
+          files: |
+            LICENSE
+            aarch64-linux-discord_bots
+            win64-discord_bots.exe
+            amd64-linux-discord_bots
+
+# When the release has been created: create docker images in the same step to save computing time
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+
+      # Build arm image
+      - name: Build and push Docker image
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        with:
+          file: .github/action-assets/multi-platform.dockerfile
+          context: .
+          build-args: |
+            docker_arch=linux/arm64
+            binary_name=aarch64-linux-discord_bots
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.name.outputs.lowercase }}:rolling
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Build linux/amd64 image
+      - name: Build and push Docker image
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        with:
+          file: .github/action-assets/multi-platform.dockerfile
+          context: .
+          build-args: |
+            docker_arch=linux/amd64
+            binary_name=amd64-linux-discord_bots
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.name.outputs.lowercase }}:rolling
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: "Release"
 
 on:
-  tag:
-    name: "v*"
+  push:
+    tags: "v*"
 
 env:
   CARGO_TERM_COLOR: always
@@ -40,11 +40,11 @@ jobs:
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ""
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          automatic_release_tag: ${{ github.ref }}
           prerelease: false
           draft: true
-          title: "${{ ref.event }}"
+          title: ${{ github.ref }}
           files: |
             LICENSE
             aarch64-linux-discord_bots
@@ -82,7 +82,7 @@ jobs:
             binary_name=aarch64-linux-discord_bots
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ steps.name.outputs.lowercase }}:rolling
+            ${{ env.REGISTRY }}/${{ steps.name.outputs.lowercase }}:${{ github.ref }}
           labels: ${{ steps.meta.outputs.labels }}
 
       # Build linux/amd64 image
@@ -96,5 +96,5 @@ jobs:
             binary_name=amd64-linux-discord_bots
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ steps.name.outputs.lowercase }}:rolling
+            ${{ env.REGISTRY }}/${{ steps.name.outputs.lowercase }}:${{ github.ref }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Adds a new Workflow that runs on every tag and publishes a draft release, after it has built the binaries.

This enables the maintainers to edit the Change log text before publishing the release.