### PR TITLE
[Actions] Fixes workflow "release"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/checkout@v2
       
-      - name: Extract Tag name
+      - name: Extract tag name
         id: tag_name
         run: echo ::set-output name=NAME::$(echo ${{ github.ref }} | cut -d / -f 3)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - name: Make Repository name lowercase
+      - name: Make repository name lowercase
         id: name
         uses: ASzc/change-string-case-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ jobs:
           string: ${{ env.IMAGE_NAME }}
 
       - uses: actions/checkout@v2
+      
+      - name: Extract Tag name
+        id: tag_name
+        run: echo ::set-output name=NAME::$(echo ${{ github.ref }} | cut -d / -f 3)
 
       - name: Setup cross compilation
         run: cargo install cross
@@ -41,10 +45,10 @@ jobs:
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: ${{ github.ref }}
+          automatic_release_tag: ${{ steps.tag_name.outputs.NAME }}
           prerelease: false
           draft: true
-          title: ${{ github.ref }}
+          title: ${{ steps.tag_name.outputs.NAME }}
           files: |
             LICENSE
             aarch64-linux-discord_bots
@@ -82,7 +86,7 @@ jobs:
             binary_name=aarch64-linux-discord_bots
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ steps.name.outputs.lowercase }}:${{ github.ref }}
+            ${{ env.REGISTRY }}/${{ steps.name.outputs.lowercase }}:${{ steps.tag_name.outputs.NAME }}-arm
           labels: ${{ steps.meta.outputs.labels }}
 
       # Build linux/amd64 image
@@ -96,5 +100,5 @@ jobs:
             binary_name=amd64-linux-discord_bots
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ steps.name.outputs.lowercase }}:${{ github.ref }}
+            ${{ env.REGISTRY }}/${{ steps.name.outputs.lowercase }}:${{ steps.tag_name.outputs.NAME }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This fixes the tagging of docker images, as it removes the leading `ref/tags/` from the tag name.

## What has happened?
The variable `${{ github.ref }}` gave a tag name in the reference format back: e. g. [`refs/tags/v0.1.0`](https://github.com/MaFeLP/discord_bots/actions/runs/1613337558). As docker is not able to tag an image named `ghcr.io/MaFeLP/discord_bots:refs/tags/v0.1.0` due to an invalid tagging format (too many slashes).

## How was it fixed?
This Commit updates the [release.yml](./.github/workflows/release.yml) file to include a step in which `refs/tags/` is cut from the tag name. Therefore no issues should occur, when pushing tags.