### PR TITLE
Switch from lazy_static to once_cell for lazy evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "ctrlc",
- "lazy_static",
  "log",
  "log4rs",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"
@@ -1630,6 +1630,7 @@ dependencies = [
  "lazy_static",
  "log",
  "log4rs",
+ "once_cell",
  "rand 0.8.4",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.8.1"
 log = "0.4.14"
 log4rs = { version = "1.0.0", features = ["gzip", "rolling_file_appender", "fixed_window_roller", "yaml_format"] }
 anyhow = "1.0.52"
+once_cell = "1.9.0"
 
 [dependencies.serenity]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ exclude = [".env", "config.toml", "log4rs.yml"]
 tokio = { version = "1.15", features = ["macros", "rt-multi-thread"] }
 ctrlc = "3.2"
 regex = "1.5"
-lazy_static = "1.4"
 toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 rand = "0.8.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,7 @@
+#[macro_export]
+macro_rules! regex {
+    ($re:literal $(,)?) => {{
+        static RE: once_cell::sync::OnceCell<regex::Regex> = once_cell::sync::OnceCell::new();
+        RE.get_or_init(|| regex::Regex::new($re).unwrap())
+    }};
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,4 @@
+/// This macro has just been copied from the [once_cell documentation](https://docs.rs/once_cell/1.9.0/once_cell/index.html#lazily-compiled-regex)
 #[macro_export]
 macro_rules! regex {
     ($re:literal $(,)?) => {{

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use log::{debug, error, info, trace, warn};
 use regex::Regex;
 use serde::Deserialize;
 use toml::value;
+use crate::regex;
 
 /// The response that is injected into a panic, if the config file was configured falsely
 const PANIC_RESPONSE: &str = "Please create a config file yourself or try setting the environment CONFIG_FILE to valid file location!";
@@ -40,8 +41,6 @@ lazy_static! {
     /// ```
     ///
     pub static ref CONFIG: Arc<Mutex<Config>> = Arc::new(Mutex::new(Config::new()));
-
-    static ref VERSION_REGEX: Regex = Regex::new("(?m)^version *= *\"(?P<version>\\d*\\.\\d*)\" *(|#.*)$").unwrap();
 }
 
 #[derive(Deserialize)]
@@ -208,7 +207,7 @@ fn make_default_config(config_file: &String) {
 fn check_version(config_content: &str) -> (bool, &str) {
     // Get the version, by searching for the config line and getting the version part of it.
     let version = {
-        let captures = match VERSION_REGEX.captures(config_content) {
+        let captures = match regex!("(?m)^version *= *\"(?P<version>\\d*\\.\\d*)\" *(|#.*)$").captures(config_content) {
             Some(c) => c,
             None => {
                 error!("Could not find a version in your config file!");

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 use log::{debug, error, info, trace, warn};
+use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Deserialize;
 use toml::value;
@@ -21,27 +22,23 @@ const COMPATIBLE_VERSIONS: [(u32, u32); 2] = [
     (0, 3),
 ];
 
-lazy_static! {
-    ///
-    /// The global, thread safe configuration of all of this bot.
-    ///
-    /// Examples:
-    /// ```
-    /// let config_arc = Arc::clone(&CONFIG);
-    /// let mut config_lock = config_arc.lock();
-    /// let value = match config_lock {
-    ///     Ok(config) => {
-    ///         // ACCESS CONFIG FIELDS HERE AND COPY THEM INTO VALUE
-    ///         // Example: String::from(&config.autokommentator.token)
-    ///     },
-    ///     Err(why) => {
-    ///         panic!("Something went wrong internally: {:?}\nMutex is poisoned: {}", why, why);
-    ///     }
-    /// };
-    /// ```
-    ///
-    pub static ref CONFIG: Arc<Mutex<Config>> = Arc::new(Mutex::new(Config::new()));
-}
+///
+/// The global, thread safe configuration of all of this bot.
+///
+/// Examples:
+/// ```
+/// let value = match CONFIG.lock() {
+///     Ok(config) => {
+///         // ACCESS CONFIG FIELDS HERE AND COPY THEM INTO VALUE
+///         // Example: String::from(&config.autokommentator.token)
+///     },
+///     Err(why) => {
+///         panic!("Something went wrong internally: {:?}\nMutex is poisoned: {}", why, why);
+///     }
+/// };
+/// ```
+///
+pub static CONFIG: Lazy<Mutex<Config>> = Lazy::new(|| Mutex::new(Config::new()));
 
 #[derive(Deserialize)]
 /// The default configuration struct that holds the global configuration structure

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,11 +4,10 @@ use std::{
     path::Path,
     io::Write,
     process::exit,
-    sync::{Arc, Mutex},
+    sync::Mutex,
 };
 use log::{debug, error, info, trace, warn};
 use once_cell::sync::Lazy;
-use regex::Regex;
 use serde::Deserialize;
 use toml::value;
 use crate::regex;

--- a/src/kaenguru/euro_to_mark.rs
+++ b/src/kaenguru/euro_to_mark.rs
@@ -1,4 +1,5 @@
 use regex::Regex;
+use crate::regex;
 
 /// The errors that can occur in the
 pub enum Error {
@@ -6,20 +7,6 @@ pub enum Error {
     TooBig,
     /// When no number could be found in the input string
     InvalidInput,
-}
-
-lazy_static! {
-    /// The regular expression used to parse the message into correctly formatted euro amounts
-    ///
-    /// # Examples
-    ///
-    /// * 99,10 € -> 99
-    /// * 98923 € -> 98923
-    /// * 91.897 € -> 91897
-    /// * 99,10 EUR -> 99
-    /// * 98923 EUR -> 98923
-    /// * 91.897 EUR -> 91897
-    static ref PARSING: Regex = Regex::new(r"(?is)(?:\d\.?)*\d(?:,\d+)? ?(?:EUR|€)").unwrap();
 }
 
 /// Function to extract the last euro amount from a message
@@ -48,7 +35,17 @@ lazy_static! {
 /// };
 /// ```
 pub fn get_euro(message: &str) -> Result<u64, Error> {
-    let result = PARSING.find_iter(message).last();
+    /// The regular expression used to parse the message into correctly formatted euro amounts
+    ///
+    /// # Examples
+    ///
+    /// * 99,10 € -> 99
+    /// * 98923 € -> 98923
+    /// * 91.897 € -> 91897
+    /// * 99,10 EUR -> 99
+    /// * 98923 EUR -> 98923
+    /// * 91.897 EUR -> 91897
+    let result = regex!(r"(?is)(?:\d\.?)*\d(?:,\d+)? ?(?:EUR|€)").find_iter(message).last();
     if result == None {
         return Err(Error::InvalidInput);
     }

--- a/src/kaenguru/euro_to_mark.rs
+++ b/src/kaenguru/euro_to_mark.rs
@@ -1,4 +1,3 @@
-use regex::Regex;
 use crate::regex;
 
 /// The errors that can occur in the
@@ -35,16 +34,16 @@ pub enum Error {
 /// };
 /// ```
 pub fn get_euro(message: &str) -> Result<u64, Error> {
-    /// The regular expression used to parse the message into correctly formatted euro amounts
-    ///
-    /// # Examples
-    ///
-    /// * 99,10 € -> 99
-    /// * 98923 € -> 98923
-    /// * 91.897 € -> 91897
-    /// * 99,10 EUR -> 99
-    /// * 98923 EUR -> 98923
-    /// * 91.897 EUR -> 91897
+    // The regular expression used to parse the message into correctly formatted euro amounts
+    //
+    // # Examples
+    //
+    // * 99,10 € -> 99
+    // * 98923 € -> 98923
+    // * 91.897 € -> 91897
+    // * 99,10 EUR -> 99
+    // * 98923 EUR -> 98923
+    // * 91.897 EUR -> 91897
     let result = regex!(r"(?is)(?:\d\.?)*\d(?:,\d+)? ?(?:EUR|€)").find_iter(message).last();
     if result == None {
         return Err(Error::InvalidInput);

--- a/src/logger/custom/trigger.rs
+++ b/src/logger/custom/trigger.rs
@@ -36,13 +36,11 @@ impl CustomTrigger {
     }
 }
 
-lazy_static!(
-    /// A global, thread-safe variable that tracks, if the logfile exists at program startup.
-    /// It is set, by [default_logger](crate::logger::default_logger) before the configuration
-    /// is constructed. It **should only be unset by [CustomTrigger::trigger]**, when the logfile
-    /// has been rolled over **ONCE** at program startup!
-    pub static ref LOG_FILE_EXISTS: AtomicBool = AtomicBool::new(false);
-);
+/// A global, thread-safe variable that tracks, if the logfile exists at program startup.
+/// It is set, by [default_logger](crate::logger::default_logger) before the configuration
+/// is constructed. It **should only be unset by [CustomTrigger::trigger]**, when the logfile
+/// has been rolled over **ONCE** at program startup!
+pub static LOG_FILE_EXISTS: AtomicBool = AtomicBool::new(false);
 
 impl Trigger for CustomTrigger {
     /// A function that checks if the log file meets the conditions for a roll-over.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod kaenguru;
 mod xd;
 mod config;
@@ -14,7 +11,7 @@ use std::{
     process::exit,
     thread::sleep,
     time::Duration,
-    sync::{Arc, atomic::Ordering},
+    sync::atomic::Ordering,
 };
 use log::{debug, error, info, trace, warn};
 use serenity::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod xd;
 mod config;
 mod replies;
 mod logger;
+mod common;
 
 use std::{
     borrow::Borrow,

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,9 +31,7 @@ async fn start_xd() {
     let xd_token = match env::var("DISCORD_TOKEN_XD") {
         Ok(s) => s,
         Err(_) => {
-            let config_arc = Arc::clone(&CONFIG);
-            let config_lock = config_arc.lock();
-            let token = match config_lock {
+            let token = match CONFIG.lock() {
                 Ok(config) => {
                     match &config.autokommentator.token {
                         Some(s) => String::from(s),
@@ -71,9 +69,7 @@ async fn start_kg() {
     let kg_token = match env::var("DISCORD_TOKEN_KAENGURU") {
         Ok(s) => s,
         Err(_) => {
-            let config_arc = Arc::clone(&CONFIG);
-            let config_lock = config_arc.lock();
-            let token = match config_lock {
+            let token = match CONFIG.lock() {
                 Ok(config) => {
                     match &config.kaenguru.token {
                         Some(s) => String::from(s),

--- a/src/replies.rs
+++ b/src/replies.rs
@@ -1,6 +1,3 @@
-use std::{
-    sync::Arc,
-};
 use log::{debug, error, info, trace};
 use rand::Rng;
 use serenity::{

--- a/src/replies.rs
+++ b/src/replies.rs
@@ -54,9 +54,7 @@ pub enum ReplyError {
 pub async fn reply_to(ctx: &Context, new_message: &Message, bot: Bots) -> Result<String, ReplyError> {
     trace!("Getting replies from configuration...");
     let replies: Vec<Response> = {
-        let config_arc = Arc::clone(&CONFIG);
-        let config_lock = config_arc.lock();
-        let reply_vector: Vec<Response> = match config_lock {
+        let reply_vector: Vec<Response> = match CONFIG.lock() {
             Ok(config) => {
                 // Copy replies vector
                 match bot {


### PR DESCRIPTION
This removes the dependency to [lazy_static](https://docs.rs/lazy_static/1.4.0/lazy_static/) and instead switches to [once_cell](https://docs.rs/once_cell/1.9.0/once_cell/index.html).
This is done because there is an open [RFC](https://github.com/rust-lang/rfcs/pull/2788) [that tries to add the functionality of once_cell to std](https://users.rust-lang.org/t/lazy-static-vs-once-cell-oncecell/58578/2). This means it would be a lot easier to switch from once_cell to the std variant once it's stabilized than from lazy_static. This is done now to prevent having a giant change should the codebase grow considerably.